### PR TITLE
Changing "errorResponses" to "responseMessages", per Swagger Spec 1.2

### DIFF
--- a/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/domain/ApiOperation.java
+++ b/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/domain/ApiOperation.java
@@ -33,7 +33,7 @@ extends DataType
 	private List<ApiOperationParameters> parameters;
 	private String summary = "";
 	private String notes;
-	private List<ApiResponse> errorResponses;
+	private List<ApiResponse> responseMessages;
 
 	public ApiOperation(Route route)
 	{
@@ -70,7 +70,7 @@ extends DataType
 		// parameters.
 		determineBodyInputParameters(m);
 
-		// Check for any swagger errorResponses
+		// Check for any swagger responseMessages
 		checkForSwaggerResponseAnnotations(m);
 
 	}
@@ -97,12 +97,12 @@ extends DataType
 	 */
 	public void addResponse(ApiResponse response)
 	{
-		if (errorResponses == null)
+		if (responseMessages == null)
 		{
-			errorResponses = new ArrayList<ApiResponse>();
+			responseMessages = new ArrayList<ApiResponse>();
 		}
 
-		errorResponses.add(response);
+		responseMessages.add(response);
 	}
 
 	/**

--- a/swagger/src/test/java/com/strategicgains/restexpress/plugin/swagger/SwaggerPluginTest.java
+++ b/swagger/src/test/java/com/strategicgains/restexpress/plugin/swagger/SwaggerPluginTest.java
@@ -296,7 +296,7 @@ public class SwaggerPluginTest
 		
 		// For second api verify the three response codes are being returned correctly.
 		r.then()
-			.root("apis[1].operations[0].errorResponses[%s].%s")
+			.root("apis[1].operations[0].responseMessages[%s].%s")
 			.body(withArgs(0, "code"), is(204))
 			.body(withArgs(0, "reason"), is("Successful update"))
 			.body(withArgs(1, "code"), is(404))


### PR DESCRIPTION
Changing "errorResponses" to "responseMessages".  This was done to better conform to Swagger 1.2.

Swagger 1.2: responseMessages: https://github.com/wordnik/swagger-spec/blob/master/versions/1.2.md#525-response-message-object
