### PR TITLE
Extending the ApiModelProperty and ApiModelRequest annotations to support creating multiple swagger models based on the same java type.

### DIFF
--- a/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/annotations/ApiModelProperty.java
+++ b/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/annotations/ApiModelProperty.java
@@ -1,0 +1,21 @@
+package com.strategicgains.restexpress.plugin.swagger.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiModelProperty {
+    String value() default "";
+    String allowableValues() default "";
+    String access() default "";
+    String notes() default "";
+    String dataType() default "";
+    String format() default "";
+    boolean required() default false;
+    int position() default 0;
+    boolean hidden() default false;
+    String[] excludeFromModels() default {};
+}

--- a/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/annotations/ApiModelRequest.java
+++ b/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/annotations/ApiModelRequest.java
@@ -11,4 +11,5 @@ public @interface ApiModelRequest
 {
 	Class<?> model();
 	boolean required() default false;
+	String modelName() default "";
 }

--- a/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/domain/ApiDeclarations.java
+++ b/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/domain/ApiDeclarations.java
@@ -138,7 +138,7 @@ public class ApiDeclarations
 
 		if (apiModelRequest != null)
 		{
-			DataType bodyType = resolver.resolve(apiModelRequest.model());
+			DataType bodyType = resolver.resolve(apiModelRequest.model(), apiModelRequest.modelName());
 			operation.addParameter(new ApiOperationParameters("body", "body",
 			    bodyType.getRef() != null ? bodyType.getRef() : bodyType
 			        .getType(), apiModelRequest.required()));

--- a/swagger/src/test/java/com/strategicgains/restexpress/plugin/swagger/DummyController.java
+++ b/swagger/src/test/java/com/strategicgains/restexpress/plugin/swagger/DummyController.java
@@ -94,9 +94,14 @@ public class DummyController
 	public void createWithApiImplicitParams(Request request, Response response) 
 	{
 	}
-	
+
 	@ApiParam(name = "title", required = true, value = "(Required) Title of the item.", defaultValue = "Title placeholder", allowableValues = "Any String")
 	public void createWithApiParam(Request request, Response response) 
+	{
+	}
+
+	@ApiModelRequest(model=DummyModel.class, modelName="AlternativeDummyModel")
+	public void createWithApiModelRequest(Request request, Response response)
 	{
 	}
 

--- a/swagger/src/test/java/com/strategicgains/restexpress/plugin/swagger/DummyModel.java
+++ b/swagger/src/test/java/com/strategicgains/restexpress/plugin/swagger/DummyModel.java
@@ -1,7 +1,7 @@
 package com.strategicgains.restexpress.plugin.swagger;
 
 import com.wordnik.swagger.annotations.ApiModel;
-import com.wordnik.swagger.annotations.ApiModelProperty;
+import com.strategicgains.restexpress.plugin.swagger.annotations.ApiModelProperty;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -51,4 +51,6 @@ public class DummyModel extends DummyBase {
     private ColorEnum color;
     @ApiModelProperty(dataType = "number")
     private BigDecimal dummy9;
+    @ApiModelProperty(dataType = "number", format = "double", excludeFromModels = {"AlternativeDummyModel"})
+    private BigDecimal dummy10;
 }

--- a/swagger/src/test/java/com/strategicgains/restexpress/plugin/swagger/SwaggerPluginTest.java
+++ b/swagger/src/test/java/com/strategicgains/restexpress/plugin/swagger/SwaggerPluginTest.java
@@ -127,6 +127,11 @@ public class SwaggerPluginTest
 			.method(HttpMethod.POST)
 			.name("Create with Api Param");
 
+		SERVER.uri("/annotations/{userId}/users/list2", controller)
+				.action("createWithApiModelRequest", HttpMethod.POST)
+				.method(HttpMethod.POST)
+				.name("Create with Implicit Params");
+
 		new SwaggerPlugin()
 			.apiVersion("1.0")
 			.swaggerVersion("1.2")
@@ -354,7 +359,23 @@ public class SwaggerPluginTest
             .body(withArgs("DummyModel", "dummy7", "format"), is("int32"))
             .body(withArgs("DummyModel", "dummy8", "type"), is("number"))
             .body(withArgs("DummyModel", "dummy8", "format"), is("double"))
-            .body(withArgs("DummyModel", "dummy9", "type"), is("number"));
+            .body(withArgs("DummyModel", "dummy9", "type"), is("number"))
+            .body(withArgs("DummyModel", "dummy10", "type"), is("number"))
+            .body(withArgs("DummyModel", "dummy10", "format"), is("double"));
+
+        // Make sure that the dummy10 property is not part of the AlternativeDummyModel model
+        r.then()
+            .root("models.%s.properties.%s")
+            .body(withArgs("AlternativeDummyModel", "dummy1"), notNullValue())
+            .body(withArgs("AlternativeDummyModel", "dummy2"), notNullValue())
+            .body(withArgs("AlternativeDummyModel", "dummy3"), notNullValue())
+            .body(withArgs("AlternativeDummyModel", "dummy4"), notNullValue())
+            .body(withArgs("AlternativeDummyModel", "dummy5"), notNullValue())
+            .body(withArgs("AlternativeDummyModel", "dummy6"), notNullValue())
+            .body(withArgs("AlternativeDummyModel", "dummy7"), notNullValue())
+            .body(withArgs("AlternativeDummyModel", "dummy8"), notNullValue())
+            .body(withArgs("AlternativeDummyModel", "dummy9"), notNullValue())
+            .body(withArgs("AlternativeDummyModel", "dummy10"), nullValue());
 
     }
 


### PR DESCRIPTION
Here is the problem this pull request is attempting to solve.  If I have a /products resource I want to be able to use the same java type in my code for both a new product being passed to a POST and an existing product being passed back from a GET. However the representations for the new and existing products are slightly different; a new product won't have an id field whereas an existing one does.  With the current swagger plugin the exact same product model will be used for both, which is incorrect.  These changes allow you to pass in a modelName to the ApiModelRequest annotation to create a new model with a different name, and then the excludeFromModels property on the ApiModelProperty annotation allows you to list specific models that the property should be excluded from.  Here is what it would look like for the product example:

ProductController.java:

```
@ApiOperation(value = "Creates a new Product")
@ApiModelRequest(model = Product.class, modeName="NewProduct", required=true)
    public Product createProduct(Request request, Response response)  {
        //Do Stuff
    }
```

Product.java:

```
public class Product {
    @ApiModelProperty(value = "Product ID", required=true, allowableValues = "A numeric that is auto generated.", excludeFromModels = {"NewProduct"})
    private Long productId;

    @ApiModelProperty(value = "Product Name", required=true)
    private String name;
}
```
