### PR TITLE
Add api operation response support

### DIFF
--- a/swagger/README.md
+++ b/swagger/README.md
@@ -76,12 +76,13 @@ The Swagger Plugin now supports several swagger annotations.
 ### @ApiOperation
 [Swagger doc for ApiOperation](https://github.com/wordnik/swagger-core/blob/master/modules/swagger-annotations/src/main/java/com/wordnik/swagger/annotations/ApiOperation.java)
 
-The two parameters that are supported in ApiOperation are value and notes.  Several of the other values are determined by inspecting the Route metadata.  These include response, httpMethod, and nickname.
+The two parameters that are supported in ApiOperation are value, notes and response.  Several of the other values are determined by inspecting the Route metadata.  These include response, httpMethod, and nickname.  If response is defined in the ApiOperation annotation, that will be used, if not, the response class will be set as the return object defined in the controller method.
 
 Example Usage:
 ```java
 @ApiOperation(value = "Get a specific course item",  // Brief description of the operation
-      notes = "This operation will return a specific course item as defined in the route.") // Detailed description of the operation
+      notes = "This operation will return a specific course item as defined in the route.", // Detailed description of the operation
+      response = Item.class) // Response type returned by the method.
 public Item getItem(Request request, Response response)
 ```
 

--- a/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/domain/ApiDeclarations.java
+++ b/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/domain/ApiDeclarations.java
@@ -125,20 +125,21 @@ public class ApiDeclarations
 		// the method has a valid response type this will get set to Void.  Do we want to default to 
 		// Reflection if response is Void?  Only issue with this is if the method returns an object,
 		// but the response is explicitly set to Void.
+		DataType returnType = null;
 		if(operation.getResponse() != null && operation.getResponse() != Void.class) {
-			operation.setType(operation.getResponse().getSimpleName());
+			//operation.setType(operation.getResponse().getSimpleName());
+			returnType = resolver.resolve(operation.getResponse());
 		} else {
-			DataType returnType = resolver.resolve(route.getAction().getGenericReturnType());
-
-			if (returnType.getRef() != null)
-			{
-				operation.setType(returnType.getRef());
-			}
-			else
-			{
-				operation.setType(returnType.getType());
-				operation.setItems(returnType.getItems());
-			}
+			returnType = resolver.resolve(route.getAction().getGenericReturnType());
+		}
+		if (returnType.getRef() != null)
+		{
+			operation.setType(returnType.getRef());
+		}
+		else
+		{
+			operation.setType(returnType.getType());
+			operation.setItems(returnType.getItems());
 		}
 
 		ApiModelRequest apiModelRequest = route.getAction().getAnnotation(

--- a/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/domain/ApiDeclarations.java
+++ b/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/domain/ApiDeclarations.java
@@ -121,27 +121,35 @@ public class ApiDeclarations
 	public void addModels(ApiOperation operation, Route route)
 	{
 		ModelResolver resolver = new ModelResolver(models);
-		DataType returnType = resolver.resolve(route.getAction().getGenericReturnType());
+		// Swagger defaults response to Void.class, so if response was not set in the annotation and
+		// the method has a valid response type this will get set to Void.  Do we want to default to 
+		// Reflection if response is Void?  Only issue with this is if the method returns an object,
+		// but the response is explicitly set to Void.
+		if(operation.getResponse() != null && operation.getResponse() != Void.class) {
+			operation.setType(operation.getResponse().getSimpleName());
+		} else {
+			DataType returnType = resolver.resolve(route.getAction().getGenericReturnType());
 
-		if (returnType.getRef() != null)
-		{
-			operation.setType(returnType.getRef());
-		}
-		else
-		{
-			operation.setType(returnType.getType());
-			operation.setItems(returnType.getItems());
+			if (returnType.getRef() != null)
+			{
+				operation.setType(returnType.getRef());
+			}
+			else
+			{
+				operation.setType(returnType.getType());
+				operation.setItems(returnType.getItems());
+			}
 		}
 
 		ApiModelRequest apiModelRequest = route.getAction().getAnnotation(
-		    ApiModelRequest.class);
+				ApiModelRequest.class);
 
 		if (apiModelRequest != null)
 		{
 			DataType bodyType = resolver.resolve(apiModelRequest.model());
 			operation.addParameter(new ApiOperationParameters("body", "body",
-			    bodyType.getRef() != null ? bodyType.getRef() : bodyType
-			        .getType(), apiModelRequest.required()));
+					bodyType.getRef() != null ? bodyType.getRef() : bodyType
+							.getType(), apiModelRequest.required()));
 		}
 	}
 }

--- a/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/domain/ApiOperation.java
+++ b/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/domain/ApiOperation.java
@@ -204,6 +204,10 @@ extends DataType
 
 	}
 
+	/**
+	 * Return the response class
+	 * @return
+	 */
 	public Class<?> getResponse() {
 		return response;
 	}

--- a/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/domain/ApiOperation.java
+++ b/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/domain/ApiOperation.java
@@ -34,6 +34,7 @@ extends DataType
 	private String summary = "";
 	private String notes;
 	private List<ApiResponse> responseMessages;
+	private Class<?> response;
 
 	public ApiOperation(Route route)
 	{
@@ -50,6 +51,9 @@ extends DataType
 			// value is a brief description, notes a more detailed description.
 			if (ao.value() != null) summary = ao.value();
 			if (ao.notes() != null) notes = ao.notes();
+			if (ao.response() != null) {
+				response = ao.response();
+			}
 		}
 
 		this.method = route.getMethod().getName();
@@ -198,6 +202,10 @@ extends DataType
 			}
 		}
 
+	}
+
+	public Class<?> getResponse() {
+		return response;
 	}
 
 }

--- a/swagger/src/test/java/com/strategicgains/restexpress/plugin/swagger/AnotherReturnType.java
+++ b/swagger/src/test/java/com/strategicgains/restexpress/plugin/swagger/AnotherReturnType.java
@@ -1,0 +1,27 @@
+/*
+    Copyright 2014, Strategic Gains, Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+package com.strategicgains.restexpress.plugin.swagger;
+
+/**
+ * 
+ * @author uritzry
+ * @since Aug 20, 2014
+ */
+public class AnotherReturnType {
+	
+	private String someValue;
+
+}

--- a/swagger/src/test/java/com/strategicgains/restexpress/plugin/swagger/DummyController.java
+++ b/swagger/src/test/java/com/strategicgains/restexpress/plugin/swagger/DummyController.java
@@ -73,8 +73,9 @@ public class DummyController
 	}
 	
 	@ApiOperation(value = "Read with Annotations.", 
-		notes = "More detailed description here.")
-	public Another readWithApiOperationAnnotation(Request request, Response response) 
+		notes = "More detailed description here.",
+		response = Another.class)
+	public AnotherReturnType readWithApiOperationAnnotation(Request request, Response response) 
 	{
 		return null;
 	}

--- a/swagger/src/test/java/com/strategicgains/restexpress/plugin/swagger/SwaggerPluginTest.java
+++ b/swagger/src/test/java/com/strategicgains/restexpress/plugin/swagger/SwaggerPluginTest.java
@@ -284,6 +284,8 @@ public class SwaggerPluginTest
 	public void shouldReturnAnnotationsApi()
 	{
 		Response r = get("/api-docs/annotations");
+		String json = r.asString();
+		System.out.println(json);
 		SwaggerAssert.common(r);
 		r.then()
 			.body("basePath", equalTo(BASE_URL))
@@ -294,7 +296,8 @@ public class SwaggerPluginTest
 			.root("apis[%s].%s")
 			.body(withArgs(0, "path"), is("/annotations/{userId}/users"))
 			.body(withArgs(0, "description"), is("Read with Annotations"))
-			.body(withArgs(0, "operations"), hasItem(hasEntry("method", "GET")))			
+			.body(withArgs(0, "operations"), hasItem(hasEntry("method", "GET")))
+			.body(withArgs(0, "operations"), hasItem(hasEntry("type", "Another")))
 			.body(withArgs(0, "operations"), hasItem(hasEntry("nickname", "GET Read with Annotations")))
 			.body(withArgs(0, "operations"), hasItem(hasEntry("summary", "Read with Annotations.")))
 			.body(withArgs(0, "operations"), hasItem(hasEntry("notes", "More detailed description here.")));


### PR DESCRIPTION
Added a check for response parameter in ApiOperation annotation.  If present, the return type will be set to the response value set in the annotation.  Otherwise, the type will be set to the return type of the method, as it was before.