### PR TITLE
ObjectId is a special case in RestExpress as it is parsed as a string

### DIFF
--- a/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/ModelResolver.java
+++ b/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/ModelResolver.java
@@ -211,6 +211,10 @@ public class ModelResolver
 			{
 				node.setType(Primitives.BYTE);
 			}
+			else if (targetClass.getSimpleName().equals("ObjectId") )
+			{
+				node.setType(Primitives.STRING);
+			}
 			else if (Date.class.equals(target))
 			{
 				node.setType(Primitives.DATE_TIME);


### PR DESCRIPTION
Since the ObjectId is a special case in RestExpress and is parsed as a String, it is necessary to change the Swagger plugin to reflect ObjectIds as Strings.  The swagger pluggin doesn't directly know about ObjectIds so the className is compared to "ObjectId" instead of using "instanceOf".