### PR TITLE
responseMessages should have message not reason attributes

### DIFF
--- a/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/domain/ApiResponse.java
+++ b/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/domain/ApiResponse.java
@@ -13,12 +13,12 @@ extends DataType
 	private int code;
 
 	// Reason for the response code used.
-	private String reason;
+	private String message;
 
 	public ApiResponse(int code, String message)
 	{
 		this.code = code;
-		this.reason = message;
+		this.message = message;
 	}
 
 	public int getCode()
@@ -26,8 +26,8 @@ extends DataType
 		return code;
 	}
 
-	public String getReason()
+	public String getMessage()
 	{
-		return reason;
+		return message;
 	}
 }

--- a/swagger/src/test/java/com/strategicgains/restexpress/plugin/swagger/SwaggerPluginTest.java
+++ b/swagger/src/test/java/com/strategicgains/restexpress/plugin/swagger/SwaggerPluginTest.java
@@ -303,11 +303,11 @@ public class SwaggerPluginTest
 		r.then()
 			.root("apis[1].operations[0].responseMessages[%s].%s")
 			.body(withArgs(0, "code"), is(204))
-			.body(withArgs(0, "reason"), is("Successful update"))
+			.body(withArgs(0, "message"), is("Successful update"))
 			.body(withArgs(1, "code"), is(404))
-			.body(withArgs(1, "reason"), is("Item not found"))
+			.body(withArgs(1, "message"), is("Item not found"))
 			.body(withArgs(2, "code"), is(400))
-			.body(withArgs(2, "reason"), is("Item id incorrect format"));
+			.body(withArgs(2, "message"), is("Item id incorrect format"));
 		
 		// For third api verify the parameters are being returned correctly.
 		r.then()


### PR DESCRIPTION
This matches responseMessage.reason defined at https://github.com/swagger-api/swagger-spec/blob/master/versions/1.2.md#525-response-message-object