### PR TITLE
ensure empty parameters array exist even when no params present

### DIFF
--- a/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/domain/ApiOperation.java
+++ b/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/domain/ApiOperation.java
@@ -37,6 +37,8 @@ extends DataType
 
 	public ApiOperation(Route route)
 	{
+		this.parameters = new ArrayList<ApiOperationParameters>();
+
 		// TODO: use Swagger annotation on controller method, if present.
 		// Get the method from the route
 		Method m = route.getAction();
@@ -82,11 +84,6 @@ extends DataType
 	 */
 	public void addParameter(ApiOperationParameters param)
 	{
-		if (parameters == null)
-		{
-			parameters = new ArrayList<ApiOperationParameters>();
-		}
-
 		parameters.add(param);
 	}
 

--- a/swagger/src/test/java/com/strategicgains/restexpress/plugin/swagger/SwaggerPluginTest.java
+++ b/swagger/src/test/java/com/strategicgains/restexpress/plugin/swagger/SwaggerPluginTest.java
@@ -275,7 +275,20 @@ public class SwaggerPluginTest
 		assertTrue(json.contains("\"resourcePath\":\"/health\""));
 		request.releaseConnection();
 	}
-	
+
+	@Test
+	public void testParametersArrayAlwaysExist()
+	throws ClientProtocolException, IOException
+	{
+		HttpGet request = new HttpGet("http://localhost:9001/api-docs/health");
+		HttpResponse response = (HttpResponse) http.execute(request);
+		HttpEntity entity = response.getEntity();
+		String json = EntityUtils.toString(entity);
+//		System.out.println(json);
+		assertTrue(json.contains("\"parameters\":[]"));
+		request.releaseConnection();
+	}
+
 	/**
 	 * Test controller methods with Swagger annotations return the
 	 * expected json values.


### PR DESCRIPTION
This matches operation.parameters defined at https://github.com/swagger-api/swagger-spec/blob/master/versions/1.2.md#523-operation-object