### PR TITLE
root (/) route is listed in /api-docs, but docs can't be found at /api-docs/

### DIFF
--- a/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/SwaggerController.java
+++ b/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/SwaggerController.java
@@ -129,6 +129,9 @@ implements Callback<RouteBuilder>
 			// Don't report the Swagger routes...
 			if (swaggerRoot.equals(path)) continue;
 
+			// Don't report the / route. It will not be resolved.
+			if ("/".equals(path)) continue;
+
 			ApiDeclarations apis = apisByPath.get(path);
 
 			if (apis == null) // new path to document

--- a/swagger/src/test/java/com/strategicgains/restexpress/plugin/swagger/SwaggerPluginTest.java
+++ b/swagger/src/test/java/com/strategicgains/restexpress/plugin/swagger/SwaggerPluginTest.java
@@ -56,6 +56,11 @@ public class SwaggerPluginTest
 
 		DummyController controller = new DummyController();
 		SERVER.setBaseUrl(BASE_URL);
+
+		SERVER.uri("/", controller)
+			.action("health", HttpMethod.GET)
+			.name("root");
+
 		SERVER.uri("/anothers/{userId}", controller)
 			.action("readAnother", HttpMethod.GET);
 
@@ -158,6 +163,7 @@ public class SwaggerPluginTest
 		System.out.println(r.asString());
 		SwaggerAssert.common(r);
 		r.then()
+			.body("apis", not(hasItem(hasEntry("path", "/"))))
 			.body("apis", hasItem(hasEntry("path", "/anothers")))
 			.body("apis", hasItem(hasEntry("path", "/users")))
 			.body("apis", hasItem(hasEntry("path", "/orders")))


### PR DESCRIPTION
This is a workaround rather than a fix.  SwaggerController's read method is never called for the "/" route. Would definitely prefer this route to be listed, but working swagger docs are more important. 