### PR TITLE
Turn off both authn and authz for OPTIONS routes added for CORS preflight

### DIFF
--- a/cors/src/main/java/com/strategicgains/restexpress/plugin/cors/CorsHeaderPlugin.java
+++ b/cors/src/main/java/com/strategicgains/restexpress/plugin/cors/CorsHeaderPlugin.java
@@ -13,6 +13,7 @@ import java.util.Set;
 
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.restexpress.ContentType;
+import org.restexpress.Flags;
 import org.restexpress.Request;
 import org.restexpress.Response;
 import org.restexpress.RestExpress;
@@ -229,7 +230,11 @@ extends AbstractPlugin
 	    {
 	    	rb = server.uri(pattern, corsOptionsController)
 		    	.action("options", HttpMethod.OPTIONS)
-		    	.noSerialization();
+		    	.noSerialization()
+		    	// Disable both authentication and authorization which are usually use header such as X-Authorization.
+		    	// When browser does CORS preflight with OPTIONS request, such headers are not included.
+		    	.flag(Flags.Auth.PUBLIC_ROUTE)
+		    	.flag(Flags.Auth.NO_AUTHORIZATION);
 
 	    	for (String flag : flags)
 	    	{


### PR DESCRIPTION
Turn off both authn and authz for OPTIONS routes added for CORS preflight purpose because browser will not include headers related to authn/authz in such calls.