### PR TITLE
Correcting version reference of Parent in LoggingPlugin

### DIFF
--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>com.strategicgains.plugin-express</groupId>
 		<artifactId>PluginExpress-Parent</artifactId>
-		<version>0.2.6-SNAPSHOT</version>
+		<version>0.2.7-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>


### PR DESCRIPTION
LoggingPlugin was referring to previous snapshot of PluginExpress, which was referring to an old no longer available snapshot of RestExpress (0.10.5-snapshot).  This causes a compile error.