### PR TITLE
Restricting the nickname to aphanumeric and underscores, per Swagger Spec

### DIFF
--- a/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/domain/ApiOperation.java
+++ b/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/domain/ApiOperation.java
@@ -61,6 +61,7 @@ extends DataType
 		this.method = route.getMethod().name();
 		String name = route.getName();
 		this.nickname = method + (name == null ? "" : " " + name);
+        this.nickname = nickname.replaceAll("[^a-zA-Z0-9_]","");
 
 		if (route.getUrlParameters() == null) return;
 

--- a/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/domain/ApiOperation.java
+++ b/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/domain/ApiOperation.java
@@ -61,7 +61,7 @@ extends DataType
 		this.method = route.getMethod().name();
 		String name = route.getName();
 		this.nickname = method + (name == null ? "" : " " + name);
-        this.nickname = nickname.replaceAll("[^a-zA-Z0-9_]","");
+		this.nickname = nickname.replaceAll("[^a-zA-Z0-9_]","");
 
 		if (route.getUrlParameters() == null) return;
 

--- a/swagger/src/test/java/com/strategicgains/restexpress/plugin/swagger/SwaggerPluginTest.java
+++ b/swagger/src/test/java/com/strategicgains/restexpress/plugin/swagger/SwaggerPluginTest.java
@@ -111,6 +111,11 @@ public class SwaggerPluginTest
 			.flag("somevalue")
 			.action("health", HttpMethod.GET)
 			.name("health");
+
+
+        SERVER.uri("/nicknametest", controller)
+                .method(HttpMethod.GET)
+                .name(" |nickName sh0uld_str1p-CHARS$. ");
 		
 		SERVER.uri("/annotations/{userId}/users", controller)
 			.action("readWithApiOperationAnnotation", HttpMethod.GET)
@@ -160,7 +165,7 @@ public class SwaggerPluginTest
 	throws Exception
 	{
 		Response r = get("/api-docs");
-		System.out.println(r.asString());
+		//System.out.println(r.asString());
 		SwaggerAssert.common(r);
 		r.then()
 			.body("apis", not(hasItem(hasEntry("path", "/"))))
@@ -177,7 +182,7 @@ public class SwaggerPluginTest
 	public void shouldReturnUsersApi()
 	{
 		Response r = get("/api-docs/users");
-		System.out.println(r.asString());
+		//System.out.println(r.asString());
 		SwaggerAssert.common(r);
 		r.then()
 			.body("basePath", equalTo(BASE_URL))
@@ -223,13 +228,13 @@ public class SwaggerPluginTest
 		assertTrue(json.contains("\"swaggerVersion\":\"1.2\""));
 		assertTrue(json.contains("\"basePath\":\"http://localhost:9001\""));
 		assertTrue(json.contains("\"resourcePath\":\"/users\""));
-		assertTrue(json.contains("\"nickname\":\"GET Users Collection\""));
-		assertTrue(json.contains("\"nickname\":\"POST Users Collection\""));
-		assertFalse(json.contains("\"nickname\":\"OPTIONS Users Collection\""));
-		assertTrue(json.contains("\"nickname\":\"GET Individual User\""));
-		assertTrue(json.contains("\"nickname\":\"PUT Individual User\""));
-		assertTrue(json.contains("\"nickname\":\"DELETE Individual User\""));
-		assertFalse(json.contains("\"nickname\":\"OPTIONS Individual User\""));
+		assertTrue(json.contains("\"nickname\":\"GETUsersCollection\""));
+		assertTrue(json.contains("\"nickname\":\"POSTUsersCollection\""));
+		assertFalse(json.contains("\"nickname\":\"OPTIONSUsersCollection\""));
+		assertTrue(json.contains("\"nickname\":\"GETIndividualUser\""));
+		assertTrue(json.contains("\"nickname\":\"PUTIndividualUser\""));
+		assertTrue(json.contains("\"nickname\":\"DELETEIndividualUser\""));
+		assertFalse(json.contains("\"nickname\":\"OPTIONSIndividualUser\""));
 		assertTrue(json.contains("\"summary\":\"\""));
 		request.releaseConnection();
 	}
@@ -282,6 +287,21 @@ public class SwaggerPluginTest
 		request.releaseConnection();
 	}
 
+    @Test
+    public void testNickname()
+            throws ClientProtocolException, IOException
+    {
+        HttpGet request = new HttpGet("http://localhost:9001/api-docs/nicknametest");
+        HttpResponse response = (HttpResponse) http.execute(request);
+        HttpEntity entity = response.getEntity();
+        String json = EntityUtils.toString(entity);
+        assertTrue(json.contains("\"apiVersion\":\"1.0\""));
+        assertTrue(json.contains("\"swaggerVersion\":\"1.2\""));
+        assertTrue(json.contains("\"basePath\":\"http://localhost:9001\""));
+        assertTrue(json.contains("\"nickname\":\"GETnickNamesh0uld_str1pCHARS\""));
+        request.releaseConnection();
+    }
+
 	@Test
 	public void testParametersArrayAlwaysExist()
 	throws ClientProtocolException, IOException
@@ -304,7 +324,7 @@ public class SwaggerPluginTest
 	{
 		Response r = get("/api-docs/annotations");
 		String json = r.asString();
-		System.out.println(json);
+		//System.out.println(json);
 		SwaggerAssert.common(r);
 		r.then()
 			.body("basePath", equalTo(BASE_URL))
@@ -317,7 +337,7 @@ public class SwaggerPluginTest
 			.body(withArgs(0, "description"), is("Read with Annotations"))
 			.body(withArgs(0, "operations"), hasItem(hasEntry("method", "GET")))
 			.body(withArgs(0, "operations"), hasItem(hasEntry("type", "Another")))
-			.body(withArgs(0, "operations"), hasItem(hasEntry("nickname", "GET Read with Annotations")))
+			.body(withArgs(0, "operations"), hasItem(hasEntry("nickname", "GETReadwithAnnotations")))
 			.body(withArgs(0, "operations"), hasItem(hasEntry("summary", "Read with Annotations.")))
 			.body(withArgs(0, "operations"), hasItem(hasEntry("notes", "More detailed description here.")));
 		

--- a/swagger/src/test/java/com/strategicgains/restexpress/plugin/swagger/SwaggerPluginTest.java
+++ b/swagger/src/test/java/com/strategicgains/restexpress/plugin/swagger/SwaggerPluginTest.java
@@ -112,10 +112,9 @@ public class SwaggerPluginTest
 			.action("health", HttpMethod.GET)
 			.name("health");
 
-
-        SERVER.uri("/nicknametest", controller)
-                .method(HttpMethod.GET)
-                .name(" |nickName sh0uld_str1p-CHARS$. ");
+		SERVER.uri("/nicknametest", controller)
+			.method(HttpMethod.GET)
+			.name(" |nickName sh0uld_str1p-CHARS$. ");
 		
 		SERVER.uri("/annotations/{userId}/users", controller)
 			.action("readWithApiOperationAnnotation", HttpMethod.GET)
@@ -287,20 +286,20 @@ public class SwaggerPluginTest
 		request.releaseConnection();
 	}
 
-    @Test
-    public void testNickname()
-            throws ClientProtocolException, IOException
-    {
-        HttpGet request = new HttpGet("http://localhost:9001/api-docs/nicknametest");
-        HttpResponse response = (HttpResponse) http.execute(request);
-        HttpEntity entity = response.getEntity();
-        String json = EntityUtils.toString(entity);
-        assertTrue(json.contains("\"apiVersion\":\"1.0\""));
-        assertTrue(json.contains("\"swaggerVersion\":\"1.2\""));
-        assertTrue(json.contains("\"basePath\":\"http://localhost:9001\""));
-        assertTrue(json.contains("\"nickname\":\"GETnickNamesh0uld_str1pCHARS\""));
-        request.releaseConnection();
-    }
+	@Test
+	public void testNickname()
+	throws ClientProtocolException, IOException
+	{
+		HttpGet request = new HttpGet("http://localhost:9001/api-docs/nicknametest");
+		HttpResponse response = (HttpResponse) http.execute(request);
+		HttpEntity entity = response.getEntity();
+		String json = EntityUtils.toString(entity);
+		assertTrue(json.contains("\"apiVersion\":\"1.0\""));
+		assertTrue(json.contains("\"swaggerVersion\":\"1.2\""));
+		assertTrue(json.contains("\"basePath\":\"http://localhost:9001\""));
+		assertTrue(json.contains("\"nickname\":\"GETnickNamesh0uld_str1pCHARS\""));
+		request.releaseConnection();
+	}
 
 	@Test
 	public void testParametersArrayAlwaysExist()


### PR DESCRIPTION
The [Swagger 1.2 spec](https://github.com/swagger-api/swagger-spec/blob/master/versions/1.2.md) and [Swagger 1.2 schema](https://github.com/swagger-api/swagger-spec/blob/master/schemas/v1.2/operationObject.json) indicate that the nickname parameter is restricted to alphanumeric and underscores.  Previously functionality broke that by adding a space.  Now it strips invalid characters.