### PR TITLE
Fix map type and allow hidden apis

### DIFF
--- a/swagger/README.md
+++ b/swagger/README.md
@@ -65,6 +65,7 @@ For example:
 RestExpress server = new RestExpress()...
 
 new SwaggerPlugin("/api-docs")				// URL path is optional. Defaults to '/api-docs'
+	.setDefaultToHidden(true)				// if this is set to true then only annotated apis will be shown
 	.flag("public-route")					// optional. Set a flag on the request for this route.
 	.register(server);
 ```
@@ -76,13 +77,13 @@ The Swagger Plugin now supports several swagger annotations.
 ### @ApiOperation
 [Swagger doc for ApiOperation](https://github.com/wordnik/swagger-core/blob/master/modules/swagger-annotations/src/main/java/com/wordnik/swagger/annotations/ApiOperation.java)
 
-The three parameters that are supported in ApiOperation are value, notes and response.  Several of the other values are determined by inspecting the Route metadata.  These include response, httpMethod, and nickname.  If response is defined in the ApiOperation annotation, that will be used, if not, the response class will be set as the return object defined in the controller method.
+The four parameters that are supported in ApiOperation are value, notes, response, and hidden.  Several of the other values are determined by inspecting the Route metadata.  These include response, httpMethod, and nickname.  If response is defined in the ApiOperation annotation, that will be used, if not, the response class will be set as the return object defined in the controller method.  if the parameter "hidden" is set to true then the API will not appear in the swagger documentation.  The default for "hidden" is set to false (unless specified differently, See Usage above).
 
 Example Usage:
 ```java
 @ApiOperation(value = "Get a specific course item",  // Brief description of the operation
       notes = "This operation will return a specific course item as defined in the route.", // Detailed description of the operation
-      response = Item.class) // Response type returned by the method.
+      response = Item.class, hidden = false) // Response type returned by the method.
 public Item getItem(Request request, Response response)
 ```
 

--- a/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/ModelResolver.java
+++ b/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/ModelResolver.java
@@ -226,6 +226,9 @@ public class ModelResolver
 				    .getComponentType(), null, null, null);
 				node.setItems(new Items(componentModel));
 			}
+			else if (Map.class.isAssignableFrom(targetClass)) {
+				node.setType("object"); 
+			}
 			else if (targetClass.isEnum())
 			{
 				node.setType(Primitives.STRING);
@@ -250,6 +253,10 @@ public class ModelResolver
 			ParameterizedType parameterizedType = (ParameterizedType) target;
 			Class<?> rawType = (Class<?>) parameterizedType.getRawType();
 
+			if (Map.class.isAssignableFrom(rawType)) {
+				node.setType("object"); 
+			}
+			
 			if (Collection.class.isAssignableFrom(rawType))
 			{
 				node.setType("array");

--- a/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/SwaggerController.java
+++ b/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/SwaggerController.java
@@ -52,7 +52,7 @@ implements Callback<RouteBuilder>
 	// if set to true then route must be explicitly annotated with ApiOperation to show in swagger
 	// if false then all routes will show in swagger unless ApiOperation.hidden is set to true
 	//(backward compatiblility means this should be false unless explicitly set)
-	private static  boolean HIDDEN_UNLESS_ANNOTATION_IS_PRESENT = false;
+	private   boolean HIDDEN_UNLESS_ANNOTATION_IS_PRESENT = false;
 
 	private RestExpress server;
 	private ApiResources resources;

--- a/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/SwaggerController.java
+++ b/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/SwaggerController.java
@@ -15,6 +15,7 @@
  */
 package com.strategicgains.restexpress.plugin.swagger;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -46,11 +47,26 @@ implements Callback<RouteBuilder>
 	        "GET", "PUT", "POST", "DELETE", "HEAD"
 	    }));
 
+	
+	// determines if the route will show in swagger if it is not annotated
+	// if set to true then route must be explicitly annotated with ApiOperation to show in swagger
+	// if false then all routes will show in swagger unless ApiOperation.hidden is set to true
+	//(backward compatiblility means this should be false unless explicitly set)
+	private static  boolean HIDDEN_UNLESS_ANNOTATION_IS_PRESENT = false;
+
 	private RestExpress server;
 	private ApiResources resources;
 	private Map<String, ApiDeclarations> apisByPath = new HashMap<String, ApiDeclarations>();
 	private String swaggerRoot;
 
+	
+	public SwaggerController(RestExpress server, String apiVersion,
+		    String swaggerVersion, boolean defaultToHidden)
+		{
+			this(server,apiVersion,swaggerVersion);
+			HIDDEN_UNLESS_ANNOTATION_IS_PRESENT = defaultToHidden;
+		}
+	
 	public SwaggerController(RestExpress server, String apiVersion,
 	    String swaggerVersion)
 	{
@@ -132,6 +148,8 @@ implements Callback<RouteBuilder>
 			// Don't report the / route. It will not be resolved.
 			if ("/".equals(path)) continue;
 
+			if(isRouteHidden(route)) continue;
+			
 			ApiDeclarations apis = apisByPath.get(path);
 
 			if (apis == null) // new path to document
@@ -146,5 +164,15 @@ implements Callback<RouteBuilder>
 			ApiOperation operation = apis.addOperation(route);
 			apis.addModels(operation, route);
 		}
+	}
+	
+	private boolean isRouteHidden(Route route) {
+		Method method = route.getAction();
+		if (method.isAnnotationPresent(com.wordnik.swagger.annotations.ApiOperation.class))	{
+			com.wordnik.swagger.annotations.ApiOperation annotation = method
+			    .getAnnotation(com.wordnik.swagger.annotations.ApiOperation.class);
+			return annotation.hidden();
+		}
+		return HIDDEN_UNLESS_ANNOTATION_IS_PRESENT;
 	}
 }

--- a/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/SwaggerPlugin.java
+++ b/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/SwaggerPlugin.java
@@ -36,6 +36,9 @@ extends RoutePlugin
 	private String urlPath;
 	private String apiVersion;
 	private String swaggerVersion = SWAGGER_VERSION;
+	private boolean defaultToHidden = false;
+
+	
 
 	public SwaggerPlugin()
 	{
@@ -66,7 +69,7 @@ extends RoutePlugin
 		if (isRegistered()) return this;
 
 		super.register(server);
-		controller = new SwaggerController(server, apiVersion, swaggerVersion, true);
+		controller = new SwaggerController(server, apiVersion, swaggerVersion, isDefaultToHidden());
 
 		RouteBuilder resources = server.uri(urlPath, controller)
 		    .action("readAll", HttpMethod.GET).name("swagger.resources")
@@ -94,5 +97,20 @@ extends RoutePlugin
 	public void bind(RestExpress server)
 	{
 		controller.initialize(urlPath, server);
+	}
+	
+	public boolean isDefaultToHidden() {
+		return defaultToHidden;
+	}
+
+	/**
+	 * when set to true the swagger documentation is not visible unless an ApiOperation annotation exists for the controller method.
+	 * This allows control over which apis are advertised and which are not visible to the public 
+	 * @param defaultToHidden
+	 * @return returns this (in order to chain commands)
+	 */
+	public SwaggerPlugin setDefaultToHidden(boolean defaultToHidden) {
+		this.defaultToHidden = defaultToHidden;
+		return this;
 	}
 }

--- a/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/SwaggerPlugin.java
+++ b/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/SwaggerPlugin.java
@@ -66,7 +66,7 @@ extends RoutePlugin
 		if (isRegistered()) return this;
 
 		super.register(server);
-		controller = new SwaggerController(server, apiVersion, swaggerVersion);
+		controller = new SwaggerController(server, apiVersion, swaggerVersion, true);
 
 		RouteBuilder resources = server.uri(urlPath, controller)
 		    .action("readAll", HttpMethod.GET).name("swagger.resources")

--- a/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/domain/ApiDeclarations.java
+++ b/swagger/src/main/java/com/strategicgains/restexpress/plugin/swagger/domain/ApiDeclarations.java
@@ -181,9 +181,15 @@ public class ApiDeclarations
 		if (apiModelRequest != null)
 		{
 			DataType bodyType = resolver.resolve(apiModelRequest.model(), apiModelRequest.modelName());
-			operation.addParameter(new ApiOperationParameters("body", "body",
-					bodyType.getRef() != null ? bodyType.getRef() : bodyType
-							.getType(), apiModelRequest.required()));
+			String type =bodyType.getRef() != null ? bodyType.getRef() : bodyType.getType(); 
+			ApiOperationParameters bodyParam = new ApiOperationParameters("body", "body",
+					type, apiModelRequest.required());
+			// if the body is an array then we need to set items
+			if("array".equals(bodyParam .getType())) {
+				bodyParam.setItems(bodyType.getItems()); 
+			}
+						operation.addParameter(bodyParam);
+		
 		}
 	}
 }

--- a/swagger/src/test/java/com/strategicgains/restexpress/plugin/swagger/DummyController.java
+++ b/swagger/src/test/java/com/strategicgains/restexpress/plugin/swagger/DummyController.java
@@ -72,6 +72,14 @@ public class DummyController
 		return null;
 	}
 	
+	@ApiOperation(value = "hidden.", hidden = true, 
+			notes = "More detailed description here. hidden",
+			response = Another.class)
+		public AnotherReturnType thisIsAHiddenAPI(Request request, Response response) 
+		{
+			return null;
+		}
+	
 	@ApiOperation(value = "Read with Annotations.", 
 		notes = "More detailed description here.",
 		response = Another.class)

--- a/swagger/src/test/java/com/strategicgains/restexpress/plugin/swagger/ModelResolverTest.java
+++ b/swagger/src/test/java/com/strategicgains/restexpress/plugin/swagger/ModelResolverTest.java
@@ -87,12 +87,11 @@ public class ModelResolverTest
 //		assertEquals(Another.class.getSimpleName(), n.getItems().getRef());
 //	}
 
-//	@Test
-//	public void shouldResolveAnotherMap()
-//	{
-//		DataType n = builder.resolve(new HashMap<String, Another>().getClass());
-//		assertNotNull(n);
-//		assertEquals("array", n.getType());
-//		assertEquals(Another.class.getSimpleName(), n.getItems().getRef());
-//	}
+	@Test
+	public void shouldResolveAnotherMap()
+	{
+		DataType n = builder.resolve(new HashMap<String, Another>().getClass());
+		assertNotNull(n);
+		assertEquals("object", n.getType()); 
+	}
 }

--- a/swagger/src/test/java/com/strategicgains/restexpress/plugin/swagger/SwaggerPluginTest.java
+++ b/swagger/src/test/java/com/strategicgains/restexpress/plugin/swagger/SwaggerPluginTest.java
@@ -121,6 +121,11 @@ public class SwaggerPluginTest
 			.method(HttpMethod.GET)
 			.name("Read with Annotations");
 		
+		SERVER.uri("/annotations/hidden", controller)
+		.action("thisIsAHiddenAPI", HttpMethod.GET)
+		.method(HttpMethod.GET)
+		.name("thisIsAHiddenAPI");
+		
 		SERVER.uri("/annotations/{userId}", controller)
 			.action("updateWithApiResponse", HttpMethod.PUT)
 			.method(HttpMethod.PUT)
@@ -314,6 +319,19 @@ public class SwaggerPluginTest
 		request.releaseConnection();
 	}
 
+	/**
+	 * Test controller methods with Swagger annotations return the
+	 * expected json values.
+	 */
+	@Test
+	public void shouldNotShowHiddenApi()
+	{
+		Response r = get("/api-docs/annotations");
+		String json = r.asString();
+		System.out.println(json); 
+//		System.out.println(json);
+		assertFalse(json.contains("hidden")); 
+	}
 	/**
 	 * Test controller methods with Swagger annotations return the
 	 * expected json values.


### PR DESCRIPTION
if a return object was a Map (HashMap for example) the type was empty causing ApiGovernance to fail the swagger check.  The return was changed to "object" as specified in the Swagger docs.
Also, ObjectId was not properly handled in the SwaggerObjectConverter and was fixed.
Also, the ApiOperation flag "hidden" was implemented to allow the non-swaggering of marked routes.
Finally, a flag was added to allow (when set) only Swagger Annotated Routes (via the ApiOperation annotation) to be shown in swagger.  This allows un-annotated routes to remain undocumented.  Note: this behavior must be specifically set; the default behavior is unchanged (nothing hidden)